### PR TITLE
Allow deletion of clusters in Error and Unknown states

### DIFF
--- a/kqueen_ui/blueprints/ui/templates/ui/index.html
+++ b/kqueen_ui/blueprints/ui/templates/ui/index.html
@@ -156,7 +156,7 @@
 {% block modals %}
 
 {% for cluster in clusters %}
-  {% if cluster.state == config.CLUSTER_OK_STATE %}
+  {% if not cluster.state == config.CLUSTER_PROVISIONING_STATE %}
   {{ render_delete_modal(resource=cluster, resource_name='cluster') }}
   {% endif %}
 {% endfor %}

--- a/kqueen_ui/blueprints/ui/templates/ui/partial/tableaction.html
+++ b/kqueen_ui/blueprints/ui/templates/ui/partial/tableaction.html
@@ -6,7 +6,7 @@
 <a href="{{ url_for('ui.cluster_detail', cluster_id=cluster.id) }}"{% if not is_authorized(session, 'cluster:get', cluster) %} class="disabled"{% endif %} title="Cluster detail">
   <i class="mdi mdi-magnify"></i>
 </a>
-<a data-toggle="modal" data-target="#delete-{{ cluster.id }}"{% if cluster.state != config.CLUSTER_OK_STATE or not is_authorized(session, 'cluster:delete', cluster) %} class="disabled"{% endif %} title="Delete cluster">
+<a data-toggle="modal" data-target="#delete-{{ cluster.id }}"{% if cluster.state == config.CLUSTER_PROVISIONING_STATE or not is_authorized(session, 'cluster:delete', cluster) %} class="disabled"{% endif %} title="Delete cluster">
   <i class="mdi mdi-delete-forever"></i>
 </a>
 {% endmacro %}

--- a/kqueen_ui/blueprints/ui/views.py
+++ b/kqueen_ui/blueprints/ui/views.py
@@ -556,9 +556,9 @@ class ClusterDelete(KQueenView):
 
     def handle(self, cluster_id):
         cluster = self.kqueen_request('cluster', 'get', fnargs=(cluster_id,))
-        if cluster['state'] != app.config['CLUSTER_OK_STATE']:
+        if cluster['state'] == app.config['CLUSTER_PROVISIONING_STATE']:
             # TODO: handle state together with policies in helper for allowed table actions
-            flash('Only running clusters can be deleted.', 'warning')
+            flash('Cannot delete clusters during provisioning.', 'warning')
             return redirect(request.environ.get('HTTP_REFERER', url_for('ui.index')))
         self.kqueen_request('cluster', 'delete', fnargs=(cluster_id,))
         flash('Cluster {} successfully deleted.'.format(cluster['name']), 'success')


### PR DESCRIPTION
Allow deletion of clusters in Error and Unknown states, only clusters which cannot be deleted even with passing policy check are clusters in Provisioning state now.