### PR TITLE
prevent caching for safary browsers

### DIFF
--- a/kqueen_ui/blueprints/ui/templates/ui/base.html
+++ b/kqueen_ui/blueprints/ui/templates/ui/base.html
@@ -150,5 +150,15 @@
     {#
     {% include "ui/partial/footer.html" %}
     #}
+
+    {# Prevent caching in Safary #}
+    <script>
+      $(window).bind("pageshow", function(event) {
+          if (event.originalEvent.persisted) {
+              window.location.reload()
+          }
+      });
+    </script>
+
   </body>
 </html>


### PR DESCRIPTION
Prevent safari loading from cache when back button is clicked

related issue:
Kqueen Reverse to previous page make app freeze on Safari

jira ticket (for mirantis only): https://mirantis.jira.com/browse/PROD-17632

stackoverflow similar cases: https://stackoverflow.com/questions/8788802/prevent-safari-loading-from-cache-when-back-button-is-clicked

