### PR TITLE
Filter unhealthy Provisioners from Cluster Create form field 

### DIFF
--- a/kqueen_ui/blueprints/ui/views.py
+++ b/kqueen_ui/blueprints/ui/views.py
@@ -496,7 +496,13 @@ class ClusterCreate(KQueenView):
 
     def handle(self):
         # Get all necessary objects from backend
-        provisioners = self.kqueen_request('provisioner', 'list')
+        _provisioners = self.kqueen_request('provisioner', 'list')
+        provisioners = [
+            p
+            for p
+            in _provisioners
+            if p.get('state', app.config['PROVISIONER_UNKNOWN_STATE']) == app.config['PROVISIONER_OK_STATE']
+        ]
         engines = self.kqueen_request('provisioner', 'engines')
         engine_dict = dict([(e.pop('name'), e) for e in engines])
 

--- a/kqueen_ui/server.py
+++ b/kqueen_ui/server.py
@@ -48,7 +48,7 @@ def handle_kqueen_api_exception(e):
     redirect_to = url_for('ui.index')
     if request.url.endswith(redirect_to):
         redirect_to = url_for('ui.logout')
-    return redirect(request.environ.get('HTTP_REFERER', redirect_to))
+    return redirect(redirect_to)
 
 
 def run():


### PR DESCRIPTION
- Provisioner state is updated on demand so we can rely on it and filter out unhealthy provisioners from Cluster Create form
- Always redirect to home page after 500 from KQueen API to avoid confusion after form submission ending with rerendering the same page