### PR TITLE
docker deployment refactoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,6 @@ FROM python:3.6-slim
 WORKDIR /code
 COPY . .
 COPY --from=static_builder /app/kqueen_ui/asset/static/ /code/kqueen_ui/asset/static
-RUN pip install -e .
+RUN pip install -e . && \
+    mkdir /var/log/kqueen-ui
 CMD ./entrypoint.sh

--- a/kqueen_ui/blueprints/ui/templates/ui/login.html
+++ b/kqueen_ui/blueprints/ui/templates/ui/login.html
@@ -39,7 +39,7 @@
   </div>
   <div class="panel panel-default text-center">
     <div class="panel-body" style="font-size: 0.9em;">
-      {% if config.ENABLE_PUBLIC_REGISTRATION %}
+      {% if config.ENABLE_PUBLIC_REGISTRATION == 'True' %}
       <span>Not registered yet? Click <a href="{{ url_for('registration.register') }}">here</a> to set up your user account.</span><br>
       {% endif %}
       <span>Forgot your password? <a href="{{ url_for('ui.user_request_reset_password') }}">Request password reset</a>.</span>

--- a/kqueen_ui/config/base.py
+++ b/kqueen_ui/config/base.py
@@ -22,7 +22,7 @@ class BaseConfig:
     ENABLE_ADDONS = True
 
     # Registration
-    ENABLE_PUBLIC_REGISTRATION = False
+    ENABLE_PUBLIC_REGISTRATION = 'False'
     KQUEEN_SERVICE_USER_USERNAME = 'admin'
     KQUEEN_SERVICE_USER_PASSWORD = 'default'
 

--- a/kqueen_ui/config/prod.py
+++ b/kqueen_ui/config/prod.py
@@ -17,4 +17,4 @@ class Config(BaseConfig):
     ENABLE_ADDONS = False
 
     # Registration
-    ENABLE_PUBLIC_REGISTRATION = True
+    ENABLE_PUBLIC_REGISTRATION = 'True'

--- a/kqueen_ui/utils/logger_config.yml
+++ b/kqueen_ui/utils/logger_config.yml
@@ -19,7 +19,7 @@ handlers:
         class: logging.handlers.RotatingFileHandler
         level: DEBUG
         formatter: standard
-        filename: /tmp/kqueen.log
+        filename: /var/log/kqueen-ui/kqueen_ui.log
         maxBytes: 10485760 # 10MB
         backupCount: 20
         encoding: utf8
@@ -28,7 +28,7 @@ handlers:
         class: logging.handlers.RotatingFileHandler
         level: ERROR
         formatter: error
-        filename: /tmp/kqueen_error.log
+        filename: /var/log/kqueen-ui/kqueen_ui_error.log
         maxBytes: 10485760 # 10MB
         backupCount: 20
         encoding: utf8
@@ -37,7 +37,7 @@ handlers:
         class: logging.handlers.RotatingFileHandler
         level: DEBUG
         formatter: standard
-        filename: /tmp/kqueen_user_actions.log
+        filename: /var/log/kqueen-ui/kqueen_ui_user_actions.log
         maxBytes: 10485760 # 10MB
         backupCount: 20
         encoding: utf8


### PR DESCRIPTION
- 1/0 values for bool variables turned into True/False to increase visibility
- log directories naming refactores to avoid misunderstandings in case of using shared glusterfs volumes

PAY ATTENTION
This changes depended on another PR:
https://github.com/Mirantis/kqueen/pull/252
(For Mirantis Only):
This changes depended on MCP reclas model , so pls review also:
https://gerrit.mcp.mirantis.net/#/q/topic:kqueen+(status:open+OR+status:merged)