### PR TITLE
Disable 'Create cluster' button without provisioners

### DIFF
--- a/kqueen_ui/blueprints/ui/templates/ui/index.html
+++ b/kqueen_ui/blueprints/ui/templates/ui/index.html
@@ -12,7 +12,7 @@
 
 <div class="table-container">
   <div class="table-actions">
-    {{ render_cluster_table_actions() }}
+    {{ render_cluster_table_actions(provisioners) }}
   </div>
   <table class="table table-hover">
     <thead>

--- a/kqueen_ui/blueprints/ui/templates/ui/partial/tableaction.html
+++ b/kqueen_ui/blueprints/ui/templates/ui/partial/tableaction.html
@@ -1,7 +1,7 @@
-{% macro render_cluster_table_actions() %}
+{% macro render_cluster_table_actions(provisioners) %}
   {% set create_url = url_for('ui.cluster_create') %}
   {% set cant_create = not is_authorized(session, 'cluster:create') %}
-  <a href="{{ create_url }}" role="button" class="btn btn-primary btn-sm{% if cant_create %} disabled{% endif %}">Deploy cluster</a>
+  <a href="{{ create_url }}" role="button" class="btn btn-primary btn-sm{% if cant_create or not provisioners %} disabled{% endif %}">Deploy cluster</a>
 {% endmacro %}
 
 {% macro render_cluster_row_actions(cluster) %}


### PR DESCRIPTION
There is no reason to get user click on cluster creation
button without provisioners