### PR TITLE
Disable 'Create cluster' without healthy provisioners

### DIFF
--- a/kqueen_ui/blueprints/ui/templates/ui/index.html
+++ b/kqueen_ui/blueprints/ui/templates/ui/index.html
@@ -12,7 +12,7 @@
 
 <div class="table-container">
   <div class="table-actions">
-    {{ render_cluster_table_actions() }}
+    {{ render_cluster_table_actions(provisioners|healthy_provisioners) }}
   </div>
   <table class="table table-hover">
     <thead>

--- a/kqueen_ui/blueprints/ui/templates/ui/partial/tableaction.html
+++ b/kqueen_ui/blueprints/ui/templates/ui/partial/tableaction.html
@@ -1,7 +1,7 @@
-{% macro render_cluster_table_actions() %}
+{% macro render_cluster_table_actions(provisioners) %}
   {% set create_url = url_for('ui.cluster_create') %}
   {% set cant_create = not is_authorized(session, 'cluster:create') %}
-  <a href="{{ create_url }}" role="button" class="btn btn-primary btn-sm{% if cant_create %} disabled{% endif %}">Deploy cluster</a>
+  <a href="{{ create_url }}" role="button" class="btn btn-primary btn-sm{% if cant_create or not provisioners %} disabled{% endif %}">Deploy cluster</a>
 {% endmacro %}
 
 {% macro render_cluster_row_actions(cluster) %}

--- a/kqueen_ui/utils/filters.py
+++ b/kqueen_ui/utils/filters.py
@@ -43,6 +43,10 @@ def provisioner_status_icon_class(status):
     return PROVISIONER_STATE_MAP.get(status, 'mdi-alert-outline')
 
 
+def healthy_provisioners(provisioners):
+    return [p for p in provisioners if p['state'] == config['CLUSTER_OK_STATE']]
+
+
 def user_status_icon_class(status):
     return USER_STATE_MAP.get(status, 'mdi-alert-outline')
 
@@ -50,7 +54,8 @@ def user_status_icon_class(status):
 filters = {
     'cluster_status_icon': cluster_status_icon,
     'provisioner_status_icon_class': provisioner_status_icon_class,
-    'user_status_icon_class': user_status_icon_class
+    'user_status_icon_class': user_status_icon_class,
+    'healthy_provisioners': healthy_provisioners
 }
 
 


### PR DESCRIPTION
There is no reason to allow user to click on cluster creation
button without healthy provisioners.