### PR TITLE
Convert text URLs to a clickable links in cluster details

### DIFF
--- a/kqueen_ui/blueprints/ui/templates/ui/partial/_cluster_row.html
+++ b/kqueen_ui/blueprints/ui/templates/ui/partial/_cluster_row.html
@@ -32,7 +32,7 @@
                   {% for key, value in cluster.metadata.items() %}
                   <tr>
                     <th style="width: 300px;">{{ key }}</th>
-                    <td>{{ value }}</td>
+                    <td>{{ value|urlize(40, target="_blank") }}</td>
                   </tr>
                   {% endfor %}
                 </tbody>


### PR DESCRIPTION
* Use urlize filter, so if metadata value is a valid URL it will be clackable
  instead of simple text