### PR TITLE
Extend policy on user deletion

### DIFF
--- a/kqueen_ui/blueprints/ui/templates/ui/partial/tableaction.html
+++ b/kqueen_ui/blueprints/ui/templates/ui/partial/tableaction.html
@@ -41,7 +41,7 @@
   {% set reinvite_url = url_for('ui.user_reinvite', user_id=member.id) %}
   {% set cant_create = not is_authorized(session, 'user:create', member) %}
   {% set delete_url = url_for('ui.user_delete', user_id=member.id) %}
-  {% set cant_delete = not is_authorized(session, 'user:delete', member) %}
+  {% set cant_delete = not is_authorized(session, 'user:delete_{}'.format(member.role.lower()), member) %}
   {% if not member.active %}
   <a href="{{ reinvite_url }}"{% if cant_create %} class="disabled"{% endif %} title="Resend invitation">
     <i class="mdi mdi-email-alert"></i>

--- a/kqueen_ui/conftest.py
+++ b/kqueen_ui/conftest.py
@@ -60,7 +60,9 @@ def default_policy():
         "provisioner:list": "ALL",
         "provisioner:update": "ALL",
         "user:create": "IS_ADMIN",
-        "user:delete": "IS_ADMIN",
+        "user:delete_member": "IS_ADMIN",
+        "user:delete_admin": "IS_ADMIN",
+        "user:delete_superadmin": "IS_SUPERADMIN",
         "user:get": "ALL",
         "user:list": "ALL",
         "user:update": "ADMIN_OR_OWNER"

--- a/kqueen_ui/utils/test_filters.py
+++ b/kqueen_ui/utils/test_filters.py
@@ -46,7 +46,9 @@ def test_base_url(app):
     ('provisioner', 'list', True, True),
     ('provisioner', 'update', True, True),
     ('user', 'create', True, False),
-    ('user', 'delete', True, False),
+    ('user', 'delete_member', True, False),
+    ('user', 'delete_admin', True, False),
+    ('user', 'delete_superadmin', False, False),
     ('user', 'get', True, True),
     ('user', 'list', True, True),
     ('user', 'update', True, False)
@@ -72,6 +74,8 @@ def test_policy_handler(
     }
     resource = resources.get(resource_name)
     policy_rule = '{}:{}'.format(resource_name, action)
+    if policy_rule == 'user:delete':
+        policy_rule = '{}_{}'.format(policy_rule, resource.role)
     _authorized = policy_handler()
     authorized = _authorized.get('is_authorized')
 


### PR DESCRIPTION
Previously admin user was able to delete superadmin.
This change extends policy settings, so permissions
now it is defined for each user role.