### PR TITLE
Remove useless config defining method

### DIFF
--- a/kqueen_ui/blueprints/ui/utils.py
+++ b/kqueen_ui/blueprints/ui/utils.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 from flask_babel import format_datetime
 from kqueen_ui.api import get_kqueen_client
-from kqueen_ui.config import current_config
+from kqueen_ui.config.utils import kqueen_ui_config
 
 try:
     from secrets import choice
@@ -9,8 +9,6 @@ except ImportError:
     from random import choice
 
 import string
-
-config = current_config()
 
 
 def status_for_cluster_detail(_status):
@@ -292,9 +290,9 @@ def sanitize_resource_metadata(session, clusters, provisioners):
 
     for cluster in clusters:
         if 'state' in cluster:
-            if config.get('CLUSTER_PROVISIONING_STATE') != cluster['state']:
+            if kqueen_ui_config.get('CLUSTER_PROVISIONING_STATE') != cluster['state']:
                 deployed_clusters = deployed_clusters + 1
-            if cluster['state'] in [config.get('CLUSTER_RESIZING_STATE'), config.get('CLUSTER_OK_STATE')]:
+            if cluster['state'] in [kqueen_ui_config.get('CLUSTER_RESIZING_STATE'), kqueen_ui_config.get('CLUSTER_OK_STATE')]:
                 healthy_clusters = healthy_clusters + 1
         if 'created_at' in cluster:
             cluster['created_at'] = format_datetime(cluster['created_at'])
@@ -319,7 +317,7 @@ def sanitize_resource_metadata(session, clusters, provisioners):
 
     for provisioner in provisioners:
         if 'state' in provisioner:
-            if config.get('PROVISIONER_ERROR_STATE') != provisioner['state']:
+            if kqueen_ui_config.get('PROVISIONER_ERROR_STATE') != provisioner['state']:
                 healthy_provisioners = healthy_provisioners + 1
         if 'created_at' in provisioner:
             provisioner['created_at'] = format_datetime(provisioner['created_at'])

--- a/kqueen_ui/config/utils.py
+++ b/kqueen_ui/config/utils.py
@@ -6,28 +6,6 @@ CONFIG_FILE_DEFAULT = 'config/dev.py'
 logger = logging.getLogger('kqueen_ui')
 
 
-def select_file(config_file=None):
-    """
-    Select file to be used as a configuration.
-
-    Attributes:
-        config_file (str): Filename to be used as a configuration file
-
-    Returns:
-        str: filename to be used as a configuration file
-    """
-
-    if not config_file or config_file == 'None':
-        config_file = os.environ.get('KQUEEN_UI_CONFIG_FILE')
-        logger.debug('Config file from env variable: {}'.format(config_file))
-
-    if not config_file or config_file == 'None':
-        config_file = CONFIG_FILE_DEFAULT
-        logger.debug('Config file, using default: {}'.format(config_file))
-
-    return config_file
-
-
 def apply_env_changes(config, prefix='KQUEENUI_'):
     """
     Read env variables starting with prefix and apply
@@ -45,8 +23,8 @@ def apply_env_changes(config, prefix='KQUEENUI_'):
             setattr(config, config_key_name, value)
 
 
-def current_config(config_file=None):
-    read_file = select_file(config_file)
+def current_config():
+    read_file = os.environ.get('KQUEEN_UI_CONFIG_FILE', CONFIG_FILE_DEFAULT)
     logger.debug('Loading config from {}'.format(read_file))
 
     module_name = read_file.replace('/', '.').replace('.py', '')
@@ -58,3 +36,6 @@ def current_config(config_file=None):
     setattr(config, 'source_file', read_file)
 
     return config
+
+
+kqueen_ui_config = current_config()

--- a/kqueen_ui/gunicorn.py
+++ b/kqueen_ui/gunicorn.py
@@ -1,8 +1,9 @@
-from kqueen_ui.config import current_config
+from kqueen_ui.config.utils import kqueen_ui_config
+
 
 import multiprocessing
 
-app_config = current_config()
+app_config = kqueen_ui_config
 
 bind = "{host}:{port}".format(
     host=app_config.get('HOST'),

--- a/kqueen_ui/server.py
+++ b/kqueen_ui/server.py
@@ -1,4 +1,4 @@
-from .config import current_config
+from .config.utils import kqueen_ui_config
 
 from flask import Flask, redirect, request, url_for
 from kqueen_ui.blueprints.manager.views import manager
@@ -10,10 +10,7 @@ from kqueen_ui.utils.loggers import setup_logging
 
 import logging
 
-# Logging configuration
-config = current_config(config_file=None)
-
-setup_logging(config.get('LOG_CONFIG'), config.get('DEBUG'))
+setup_logging(kqueen_ui_config.get('LOG_CONFIG'), kqueen_ui_config.get('DEBUG'))
 logger = logging.getLogger('kqueen_ui')
 
 
@@ -25,7 +22,7 @@ def create_app(config_file=None):
     app.register_blueprint(ui, url_prefix='/ui')
 
     # load configuration
-    config = current_config(config_file)
+    config = config_file or kqueen_ui_config
     app.config.from_mapping(config.to_dict())
 
     app.jinja_env.filters.update(filters)

--- a/kqueen_ui/utils/filters.py
+++ b/kqueen_ui/utils/filters.py
@@ -1,9 +1,9 @@
 from flask import request
 from kqueen_ui.auth import is_authorized
-from kqueen_ui.config import current_config
+from kqueen_ui.config.utils import kqueen_ui_config
 from urllib.parse import urlsplit
 
-config = current_config().to_dict()
+config = kqueen_ui_config.to_dict()
 
 CLUSTER_STATE_MAP = {
     config['CLUSTER_OK_STATE']: 'mdi-cloud-check',


### PR DESCRIPTION
- To avoid multiple config calls and redundant logging
- To provide visibility of using configuration in docker container
- To avoid issues with overriding defined config in backend
- Keep possibility to define custom file in create_app() for tests and dev