### PR TITLE
Show cluster status information if provided

### DIFF
--- a/kqueen_ui/asset/dynamic/scss/main.scss
+++ b/kqueen_ui/asset/dynamic/scss/main.scss
@@ -77,8 +77,9 @@ a.disabled {
 }
 
 .cluster-status {
-  width: 50%;
+  width: 80%;
   margin: 17px auto 0 auto;
+  color: $mira-red-dark;
 }
 
 .pop-help {

--- a/kqueen_ui/blueprints/ui/templates/ui/cluster_detail.html
+++ b/kqueen_ui/blueprints/ui/templates/ui/cluster_detail.html
@@ -9,6 +9,7 @@
 {% set cant_delete = (cluster.state == config.CLUSTER_PROVISIONING_STATE or
                       not is_authorized(session, 'cluster:delete', cluster)) %}
 {% set not_ok_state = cluster.state != config.CLUSTER_OK_STATE %}
+{% set status_message = cluster.get('metadata', {}).get('status_message', {}) %}
 
 {% block content %}
 <div class="overview">
@@ -96,6 +97,9 @@
       </div>
     </div>
   </div>
+  {% if status_message %}
+  <div class="row cluster-status">{{ status_message }}</div>
+  {% endif %}
 </div>
 
 <div class="overview-actions">


### PR DESCRIPTION
GCE cluster provides status information about the reason of failed deployment.
In this commit this information is shown in the cluster detail page.
Later, we can add similar status to the rest of provisioners.

Corresponding change in API: [306](https://github.com/Mirantis/kqueen/pull/306)