### PR TITLE
Implement bulk clusters and provisioners deletion

### DIFF
--- a/kqueen_ui/asset/dynamic/js/checkboxes.js
+++ b/kqueen_ui/asset/dynamic/js/checkboxes.js
@@ -41,7 +41,7 @@ function handleBulkDelete(
   // Checkboxes will be still selected if e.g. you open cluster page and then go back,
   // so in this case delete button should be enabled
   if (!isZeroCount(checkedRowsSelector)) {
-    setDeleteButtonState(activeRowCheckboxes.is(':checked'));
+    setDeleteButtonState(true);
     setButtonTarget();
   }
 

--- a/kqueen_ui/asset/dynamic/js/checkboxes.js
+++ b/kqueen_ui/asset/dynamic/js/checkboxes.js
@@ -1,0 +1,74 @@
+function handleBulkDelete(
+  selectAllCheckboxSelector, rowCheckboxesSelector, buttonSelector, 
+  formTargetUrl, targetName
+) {
+  var selectAllCheckbox = $(selectAllCheckboxSelector),
+      activeRowCheckboxes = $(rowCheckboxesSelector + ':not(:disabled)'),
+      bulkDeleteButton = $(buttonSelector);
+  var checkedRowsSelector = rowCheckboxesSelector + ':checked',
+      notCheckedRowsSelector = rowCheckboxesSelector + ':not(:checked)';
+
+  var isZeroCount = (selector) => !$(selector).get().length;
+  var setDeleteButtonState = (enable) => {
+    // "disabled" prop is not allowed for anchors, so a class is used instead
+    enable ? bulkDeleteButton.removeClass('disabled') : bulkDeleteButton.addClass('disabled');
+  }
+  var getSelectedObjectsNames = () => $(checkedRowsSelector).map(function() {
+    return this.value;
+  }).get();
+  var getSelectedObjectsIds = () => $(checkedRowsSelector).map(function() {
+    return this.name;
+  }).get();
+  var setButtonTarget = () => {
+    bulkDeleteButton.data('target', formTargetUrl(getSelectedObjectsIds().join('+')));
+    var names = getSelectedObjectsNames();
+    var confirmationText = (
+      isZeroCount(notCheckedRowsSelector) ?
+      `ALL your ${targetName}s (${names.join(', ')})` :
+      `${targetName}${names.length === 1 ? '' : 's'} ${names.join(', ')}`
+    );
+    bulkDeleteButton.data('name', confirmationText);
+  }
+
+  // Disable select-all checkbox if all others are disabled
+  if (isZeroCount(activeRowCheckboxes)) {
+    selectAllCheckbox.prop('disabled', true);
+    var checkboxLabel = $(selectAllCheckbox.next('label')[0]);
+    checkboxLabel.addClass('disabled-wrapper');
+    $(checkboxLabel.find('.checkbox-all')[0]).addClass('disabled');
+  }
+
+  // Checkboxes will be still selected if e.g. you open cluster page and then go back,
+  // so in this case delete button should be enabled
+  if (!isZeroCount(checkedRowsSelector)) {
+    setDeleteButtonState(activeRowCheckboxes.is(':checked'));
+    setButtonTarget();
+  }
+
+  selectAllCheckbox.bind('change', function () {
+    var selectAllChecked = selectAllCheckbox.is(':checked');
+    activeRowCheckboxes.prop('checked', selectAllChecked);
+    setDeleteButtonState(selectAllChecked);
+    if (selectAllChecked) {
+      setButtonTarget();
+    }
+  });
+  activeRowCheckboxes.bind('change', function () {
+    setDeleteButtonState(activeRowCheckboxes.is(':checked'));
+    setButtonTarget();
+    if (isZeroCount(notCheckedRowsSelector)) {
+      selectAllCheckbox.prop('checked', true).trigger('change');
+    } else if (isZeroCount(checkedRowsSelector)) {
+      selectAllCheckbox.prop('checked', false).trigger('change');
+    }
+  });
+
+  // Handle table row click
+  $('tr.clickable').click(function(e) {
+    if (e.target.tagName === 'TD') {
+      var rowCheckbox = $($(e.target).parent().find(activeRowCheckboxes)[0]);
+      rowCheckbox.prop('checked', !rowCheckbox.is(':checked')).trigger('change');
+    }
+  });
+}
+

--- a/kqueen_ui/asset/dynamic/js/checkboxes.js
+++ b/kqueen_ui/asset/dynamic/js/checkboxes.js
@@ -1,7 +1,7 @@
-function handleBulkDelete(
+function handleBulkDelete({
   selectAllCheckboxSelector, rowCheckboxesSelector, buttonSelector, 
   formTargetUrl, targetName
-) {
+}) {
   var selectAllCheckbox = $(selectAllCheckboxSelector),
       activeRowCheckboxes = $(rowCheckboxesSelector + ':not(:disabled)'),
       bulkDeleteButton = $(buttonSelector);
@@ -17,7 +17,7 @@ function handleBulkDelete(
     return this.value;
   }).get();
   var getSelectedObjectsIds = () => $(checkedRowsSelector).map(function() {
-    return this.name;
+    return encodeURIComponent(this.name);
   }).get();
   var setButtonTarget = () => {
     bulkDeleteButton.data('target', formTargetUrl(getSelectedObjectsIds().join('+')));

--- a/kqueen_ui/asset/dynamic/js/checkboxes.js
+++ b/kqueen_ui/asset/dynamic/js/checkboxes.js
@@ -10,8 +10,7 @@ function handleBulkDelete({
 
   var isZeroCount = (selector) => !$(selector).get().length;
   var setDeleteButtonState = (enable) => {
-    // "disabled" prop is not allowed for anchors, so a class is used instead
-    enable ? bulkDeleteButton.removeClass('disabled') : bulkDeleteButton.addClass('disabled');
+    enable ? bulkDeleteButton.removeClass('hidden') : bulkDeleteButton.addClass('hidden');
   }
   var getSelectedObjectsNames = () => $(checkedRowsSelector).map(function() {
     return this.value;

--- a/kqueen_ui/asset/dynamic/scss/main.scss
+++ b/kqueen_ui/asset/dynamic/scss/main.scss
@@ -656,6 +656,22 @@ div.bulk-action {
   margin-top: -5px;
 }
 
+.table > tbody > tr > td.clickable-cluster-name {
+  padding: 0;
+  &:hover {
+    background: #e8e8e8;
+  }
+}
+.table-container .table div.cluster-name {
+  display: block;
+  a {
+    display: block;
+    width: 100%;
+    height: 100%;
+    padding: 8px;
+  }
+}
+
 // *****************************************************************************
 // Flicker on Load Fix for Glyphicons
 // *****************************************************************************

--- a/kqueen_ui/asset/dynamic/scss/main.scss
+++ b/kqueen_ui/asset/dynamic/scss/main.scss
@@ -43,6 +43,7 @@ h1, h2 {
 a.disabled {
   opacity: 0.5;
   pointer-events: none !important;
+  cursor: not-allowed;
 }
 
 .box {
@@ -552,6 +553,9 @@ table {
         color: $brand-danger;
       }
     }
+    .cluster-name {
+      display: inline-block;
+    }
   }
   &.no-actions {
     margin-top: 20px;
@@ -645,6 +649,11 @@ td.mdi-account {
   font-size: 22px;
   float: left;
   margin-right: 3px;
+}
+
+div.bulk-action {
+  text-align: right;
+  margin-top: -5px;
 }
 
 // *****************************************************************************

--- a/kqueen_ui/asset/dynamic/scss/main.scss
+++ b/kqueen_ui/asset/dynamic/scss/main.scss
@@ -583,11 +583,8 @@ table {
   }
 }
 
-.table-container .table.clusters-list {
-  .action_column {
-    width: 70px;
-  }
-  .status_column {
+.table-container .table.clusters-list, .table-container .table.provisioners-list {
+  .action_column, .status_column {
     width: 70px;
   }
 }
@@ -698,7 +695,7 @@ input[type="checkbox"] {
     .checkbox-all:before {
       content: "\F137"; // mdi-checkbox-multiple-blank-outline
     }
-    .checkbox-cluster:before {
+    .checkbox-row:before {
       content: "\F131"; // mdi-checkbox-blank-outline
     }
     .disabled {
@@ -710,7 +707,7 @@ input[type="checkbox"] {
     .checkbox-all:before {
       content: "\F138"; // mdi-checkbox-multiple-marked
     }
-    .checkbox-cluster:before {
+    .checkbox-row:before {
       content: "\F132"; // mdi-checkbox-marked
     }
   }

--- a/kqueen_ui/asset/dynamic/scss/main.scss
+++ b/kqueen_ui/asset/dynamic/scss/main.scss
@@ -481,6 +481,10 @@ table {
   .table-actions {
     padding-bottom: 24px;
     text-align: right;
+    .bulk-delete-clusters, .bulk-delete-provisioners {
+      margin-right: 40px;
+      height: 35px;
+    }
   }
   .table {
     .status_column {

--- a/kqueen_ui/asset/dynamic/scss/main.scss
+++ b/kqueen_ui/asset/dynamic/scss/main.scss
@@ -43,6 +43,10 @@ h1, h2 {
 a.disabled {
   opacity: 0.5;
   pointer-events: none !important;
+}
+
+.disabled-wrapper {
+  display: inline-block;
   cursor: not-allowed;
 }
 
@@ -662,6 +666,9 @@ div.bulk-action {
     background: #e8e8e8;
   }
 }
+.table-hover>tbody>tr:hover {
+}
+
 .table-container .table div.cluster-name {
   display: block;
   a {
@@ -669,6 +676,33 @@ div.bulk-action {
     width: 100%;
     height: 100%;
     padding: 8px;
+  }
+}
+
+input[type="checkbox"] {
+  display: none;
+  + label {
+    display: inline-block;
+    color: #7b7a7a;
+    cursor: pointer;
+    margin-bottom: 0;
+    .mdi:before {
+      font: normal normal normal 19px/1 "Material Design Icons";
+    }
+    .checkbox-all:before {
+      content: "\F137"; // mdi-checkbox-multiple-blank-outline
+    }
+    .checkbox-cluster:before {
+      content: "\F131"; // mdi-checkbox-blank-outline
+    }
+  }
+  &:checked + label {
+    .checkbox-all:before {
+      content: "\F138"; // mdi-checkbox-multiple-marked
+    }
+    .checkbox-cluster:before {
+      content: "\F132"; // mdi-checkbox-marked
+    }
   }
 }
 

--- a/kqueen_ui/asset/dynamic/scss/main.scss
+++ b/kqueen_ui/asset/dynamic/scss/main.scss
@@ -47,7 +47,7 @@ a.disabled {
 
 .disabled-wrapper {
   display: inline-block;
-  cursor: not-allowed;
+  cursor: not-allowed !important;
 }
 
 .box {
@@ -583,6 +583,15 @@ table {
   }
 }
 
+.table-container .table.clusters-list {
+  .action_column {
+    width: 70px;
+  }
+  .status_column {
+    width: 70px;
+  }
+}
+
 div:not(.tab-pane) {
   > .table-container {
     @extend .box;
@@ -663,12 +672,9 @@ div.bulk-action {
 .table > tbody > tr > td.clickable-cluster-name {
   padding: 0;
   &:hover {
-    background: #e8e8e8;
+    background: #ecebeb;
   }
 }
-.table-hover>tbody>tr:hover {
-}
-
 .table-container .table div.cluster-name {
   display: block;
   a {
@@ -694,6 +700,10 @@ input[type="checkbox"] {
     }
     .checkbox-cluster:before {
       content: "\F131"; // mdi-checkbox-blank-outline
+    }
+    .disabled {
+      color: #ccc;
+      pointer-events: none;
     }
   }
   &:checked + label {

--- a/kqueen_ui/asset/dynamic/scss/main.scss
+++ b/kqueen_ui/asset/dynamic/scss/main.scss
@@ -583,12 +583,6 @@ table {
   }
 }
 
-.table-container .table.clusters-list, .table-container .table.provisioners-list {
-  .action_column, .status_column {
-    width: 70px;
-  }
-}
-
 div:not(.tab-pane) {
   > .table-container {
     @extend .box;

--- a/kqueen_ui/blueprints/ui/templates/ui/cluster_detail.html
+++ b/kqueen_ui/blueprints/ui/templates/ui/cluster_detail.html
@@ -177,7 +177,7 @@
   </div>
   <div class="col-sm-3">
     <a
-      data-target="{{ url_for('ui.cluster_delete', cluster_id=cluster.id) }}"
+      data-target="{{ url_for('ui.cluster_delete', cluster_ids=[cluster.id]) }}"
       data-name="cluster {{ cluster.name }}"
       {% if cant_delete %}disabled{% endif %}
       class="confirm-delete btn btn-primary btn-xs"

--- a/kqueen_ui/blueprints/ui/templates/ui/index.html
+++ b/kqueen_ui/blueprints/ui/templates/ui/index.html
@@ -55,7 +55,7 @@
         </tbody>
       </table>
       <div class="bulk-action">
-        <a class="btn btn-default confirm-delete disabled bulk-delete" title="Delete cluster">
+        <a class="btn btn-default confirm-delete bulk-delete" title="Delete cluster">
           <i class="mdi mdi-delete-forever"></i>Delete
         </a>
       </div>
@@ -234,6 +234,7 @@ $(document).ready(function() {
     deleteButton.data('name', text);
   }
 
+  setDeleteButtonState(selectRowCheckboxes.is(':checked'));
   selectAllCheckbox.bind('change', function () {
     var allChecked = selectAllCheckbox.is(':checked');
     $('input[type="checkbox"].select-cluster').prop('checked', allChecked);

--- a/kqueen_ui/blueprints/ui/templates/ui/index.html
+++ b/kqueen_ui/blueprints/ui/templates/ui/index.html
@@ -1,5 +1,5 @@
 {% extends "ui/base.html" %}
-{% from "ui/partial/tableaction.html" import render_cluster_table_actions, render_provisioner_table_actions, render_provisioner_row_actions with context %}
+{% from "ui/partial/tableaction.html" import render_cluster_table_actions, render_provisioner_table_actions with context %}
 {% from "ui/partial/_cluster_row.html" import render_cluster_row with context %}
 {% from "ui/partial/_overview_pies.html" import render_overview_pies with context %}
 
@@ -39,8 +39,8 @@
         <thead>
           <th class="col-md-1">
             {% if clusters %}
-              <input type="checkbox" class="select-all" id="select-all" />
-              <label for="select-all"><i class="mdi checkbox-all"></i></label>
+              <input type="checkbox" class="select-all-clusters" id="select-all-clusters" />
+              <label for="select-all-clusters"><i class="mdi checkbox-all"></i></label>
             {% endif %}
           </th>
           <th class="col-md-4">Name</th>
@@ -60,7 +60,10 @@
       {% if clusters %}
         <div class="bulk-action">
           <div class="disabled-wrapper">
-            <a class="btn btn-default confirm-delete bulk-delete" title="Delete cluster">
+            <a
+              class="btn btn-default disabled confirm-delete bulk-delete-clusters"
+              title="Delete cluster"
+            >
               <i class="mdi mdi-delete-forever"></i>Delete
             </a>
           </div>
@@ -82,20 +85,47 @@
           </div>
         </div>
       </div>
-      <table class="table table-hover">
+      <table class="table table-hover provisioners-list">
         <thead>
+          <th class="col-md-1">
+            {% if provisioners %}
+              <input
+                type="checkbox"
+                class="select-all-provisioners"
+                id="select-all-provisioners"
+              />
+              <label for="select-all-provisioners"><i class="mdi checkbox-all"></i></label>
+            {% endif %}
+          </th>
           <th class="col-md-4">Name</th>
-          <th class="col-md-4">Engine</th>
+          <th class="col-md-3">Engine</th>
           <th class="col-md-4">Created</th>
           <th class="status_column">Status</th>
           <th class="action_column">Actions</th>
         </thead>
         <tbody>
           {% for provisioner in provisioners %}
-            <tr>
+            {% set cant_delete = not is_authorized(session, 'provisioner:delete', provisioner) %}
+            <tr class="clickable">
+              <td class="col-md-1">
+                <input
+                  type="checkbox"
+                  id="select-provisioner-{{ provisioner.id }}"
+                  {% if cant_delete %} disabled{% endif %}
+                  class="select-provisioner"
+                  name="{{ provisioner.id }}"
+                  value="{{ provisioner.name }}"
+                />
+                <label
+                  for="select-provisioner-{{ provisioner.id }}"
+                  {% if cant_delete %}class="disabled-wrapper"{% endif %}
+                >
+                  <i class="mdi checkbox-row{% if cant_delete %} disabled{% endif %}"></i>
+                </label>
+              </td>
               <td class="col-md-4">{{ provisioner.name }}</td>
               <td class="col-md-4">{{ provisioner.verbose_name }}</td>
-              <td class="col-md-4">{{ provisioner.created_at }}</td>
+              <td class="col-md-3">{{ provisioner.created_at }}</td>
               <td class="status_column"><i class="mdi {{ provisioner.state|provisioner_status_icon_class }}" title="{{ provisioner.state }}"></i></td>
               <td class="action_column">
                 {% if provisioner.parameters %}
@@ -107,7 +137,6 @@
                   <i class="mdi mdi-information-outline"></i>
                 </a>
                 {% endif %}
-                {{ render_provisioner_row_actions(provisioner) }}
               </td>
             </tr>
             {% if provisioner.parameters %}
@@ -133,6 +162,18 @@
           {% endfor %}
         </tbody>
       </table>
+      {% if provisioners %}
+        <div class="bulk-action">
+          <div class="disabled-wrapper">
+            <a
+              class="btn btn-default disabled confirm-delete bulk-delete-provisioners"
+              title="Delete provisioner"
+            >
+              <i class="mdi mdi-delete-forever"></i>Delete
+            </a>
+          </div>
+        </div>
+      {% endif %}
     </div>
   </div>
 </div>
@@ -203,64 +244,20 @@ setInterval(function(){
 }, 15000);
 
 $(document).ready(function() {
-  // Bulk delete operation on clusters
-  var selectAllCheckbox = $('input[type="checkbox"].select-all'),
-      selectRowCheckboxes = $('input[type="checkbox"]:not(:disabled).select-cluster'),
-      deleteButton = $('a.bulk-delete'),
-      checkedRowsSelector = 'input[type="checkbox"].select-cluster:checked';
-
-  if (!$(selectRowCheckboxes).get().length) {
-    selectAllCheckbox.prop('disabled', true);
-    var label = $(selectAllCheckbox.next('label')[0]);
-    label.addClass('disabled-wrapper');
-    $(label.find('.checkbox-all')[0]).addClass('disabled');
-  }
-
-  var setDeleteButtonState = (enable) => {
-    // "disabled" prop is not allowed for anchors, so we use classes instead
-    enable ? deleteButton.removeClass('disabled') : deleteButton.addClass('disabled');
-  }
-  var getSelectedClusterNames = () => $(checkedRowsSelector).map(function() {
-    return this.value;
-  }).get();
-  var getSelectedClusterIds = () => $(checkedRowsSelector).map(function() {
-    return this.name;
-  }).get();
-  var setButtonTarget = () => {
-    deleteButton.data('target', `/ui/clusters/${getSelectedClusterIds().join('+')}/delete_bulk`);
-    var text = '',
-        names = getSelectedClusterNames();
-    if (!$('input[type="checkbox"].select-cluster:not(:checked)').get().length) {
-      text = `ALL your clusters (${names.join(', ')})`;
-    } else {
-      text = `cluster${names.length === 1 ? '' : 's'} ${names.join(', ')}`;
-    }
-    deleteButton.data('name', text);
-  }
-
-  setDeleteButtonState(selectRowCheckboxes.is(':checked'));
-  setButtonTarget();
-
-  selectAllCheckbox.bind('change', function () {
-    var allChecked = selectAllCheckbox.is(':checked');
-    selectRowCheckboxes.prop('checked', allChecked);
-    setDeleteButtonState(allChecked);
-    if (allChecked) {
-      setButtonTarget();
-    }
-  });
-  selectRowCheckboxes.bind('change', function () {
-    setDeleteButtonState(selectRowCheckboxes.is(':checked'));
-    setButtonTarget();
-  });
-
-  // Handle table row click
-  $('tr.clickable').click(function(e) {
-    if (e.target.tagName === 'TD') {
-      var rowCheckbox = $($(e.target).parent().find(selectRowCheckboxes)[0]);
-      rowCheckbox.prop('checked', !rowCheckbox.is(':checked')).trigger('change');
-    }
-  });
+  handleBulkDelete(
+    'input[type="checkbox"].select-all-clusters',
+    'input[type="checkbox"].select-cluster',
+    'a.bulk-delete-clusters',
+    (ids) => `/ui/clusters/${ids}/delete_bulk`,
+    'cluster'
+  );
+  handleBulkDelete(
+    'input[type="checkbox"].select-all-provisioners',
+    'input[type="checkbox"].select-provisioner',
+    'a.bulk-delete-provisioners',
+    (ids) => `/ui/provisioners/${ids}/delete_bulk`,
+    'provisioner'
+  );
 });
 </script>
 {% endblock %}

--- a/kqueen_ui/blueprints/ui/templates/ui/index.html
+++ b/kqueen_ui/blueprints/ui/templates/ui/index.html
@@ -1,5 +1,5 @@
 {% extends "ui/base.html" %}
-{% from "ui/partial/tableaction.html" import render_cluster_table_actions, render_provisioner_table_actions with context %}
+{% from "ui/partial/tableaction.html" import render_cluster_table_actions, render_provisioner_table_actions, render_provisioner_row_actions with context %}
 {% from "ui/partial/_cluster_row.html" import render_cluster_row with context %}
 {% from "ui/partial/_overview_pies.html" import render_overview_pies with context %}
 
@@ -31,13 +31,21 @@
         </div>
         <div class="col-xs-4">
           <div class="table-actions">
+            {% if clusters %}
+              <a
+                class="btn btn-danger btn-sm hidden confirm-delete bulk-delete-clusters"
+                title="Delete cluster"
+              >
+                <i class="mdi mdi-delete-forever"></i> Delete
+              </a>
+            {% endif %}
             {{ render_cluster_table_actions(provisioners|healthy_provisioners) }}
           </div>
         </div>
       </div>
       <table class="table table-hover">
         <thead>
-          <th class="col-md-1">
+          <th>
             {% if clusters %}
               <input type="checkbox" class="select-all-clusters" id="select-all-clusters" />
               <label for="select-all-clusters"><i class="mdi checkbox-all"></i></label>
@@ -45,9 +53,9 @@
           </th>
           <th class="col-md-4">Name</th>
           <th class="col-md-4">Provisioner</th>
-          <th class="col-md-3">Created</th>
+          <th class="col-md-4">Created</th>
           <th class="status_column">Status</th>
-          <th class="action_column">Info</th>
+          <th class="action_column">Actions</th>
         </thead>
         <tbody>
           {% for cluster in clusters %}
@@ -57,18 +65,6 @@
           {% endfor %}
         </tbody>
       </table>
-      {% if clusters %}
-        <div class="bulk-action">
-          <div class="disabled-wrapper">
-            <a
-              class="btn btn-default disabled confirm-delete bulk-delete-clusters"
-              title="Delete cluster"
-            >
-              <i class="mdi mdi-delete-forever"></i>Delete
-            </a>
-          </div>
-        </div>
-      {% endif %}
     </div>
   </div>
 
@@ -81,13 +77,21 @@
         </div>
         <div class="col-xs-4">
           <div class="table-actions">
+            {% if provisioners %}
+              <a
+                class="btn btn-danger btn-sm hidden confirm-delete bulk-delete-provisioners"
+                title="Delete provisioner"
+              >
+                <i class="mdi mdi-delete-forever"></i> Delete
+              </a>
+            {% endif %}
             {{ render_provisioner_table_actions() }}
           </div>
         </div>
       </div>
       <table class="table table-hover">
         <thead>
-          <th class="col-md-1">
+          <th>
             {% if provisioners %}
               <input
                 type="checkbox"
@@ -98,7 +102,7 @@
             {% endif %}
           </th>
           <th class="col-md-4">Name</th>
-          <th class="col-md-3">Engine</th>
+          <th class="col-md-4">Engine</th>
           <th class="col-md-4">Created</th>
           <th class="status_column">Status</th>
           <th class="action_column">Actions</th>
@@ -107,7 +111,7 @@
           {% for provisioner in provisioners %}
             {% set cant_delete = not is_authorized(session, 'provisioner:delete', provisioner) %}
             <tr class="clickable">
-              <td class="col-md-1">
+              <td>
                 <input
                   type="checkbox"
                   id="select-provisioner-{{ provisioner.id }}"
@@ -125,7 +129,7 @@
               </td>
               <td class="col-md-4">{{ provisioner.name }}</td>
               <td class="col-md-4">{{ provisioner.verbose_name }}</td>
-              <td class="col-md-3">{{ provisioner.created_at }}</td>
+              <td class="col-md-4">{{ provisioner.created_at }}</td>
               <td class="status_column"><i class="mdi {{ provisioner.state|provisioner_status_icon_class }}" title="{{ provisioner.state }}"></i></td>
               <td class="action_column">
                 {% if provisioner.parameters %}
@@ -137,6 +141,7 @@
                   <i class="mdi mdi-information-outline"></i>
                 </a>
                 {% endif %}
+                {{ render_provisioner_row_actions(provisioner) }}
               </td>
             </tr>
             {% if provisioner.parameters %}
@@ -162,18 +167,6 @@
           {% endfor %}
         </tbody>
       </table>
-      {% if provisioners %}
-        <div class="bulk-action">
-          <div class="disabled-wrapper">
-            <a
-              class="btn btn-default disabled confirm-delete bulk-delete-provisioners"
-              title="Delete provisioner"
-            >
-              <i class="mdi mdi-delete-forever"></i>Delete
-            </a>
-          </div>
-        </div>
-      {% endif %}
     </div>
   </div>
 </div>

--- a/kqueen_ui/blueprints/ui/templates/ui/index.html
+++ b/kqueen_ui/blueprints/ui/templates/ui/index.html
@@ -35,17 +35,19 @@
           </div>
         </div>
       </div>
-      <table class="table table-hover">
+      <table class="table table-hover clusters-list">
         <thead>
-          <th class="col-md--1">
-            <input type="checkbox" class="select-all" id="select-all" />
-            <label for="select-all"><i class="mdi checkbox-all"></i></label>
+          <th class="col-md-1">
+            {% if clusters %}
+              <input type="checkbox" class="select-all" id="select-all" />
+              <label for="select-all"><i class="mdi checkbox-all"></i></label>
+            {% endif %}
           </th>
-          <th class="col-md-3">Name</th>
-          <th class="col-md-4"">Provisioner</th>
-          <th class="col-md-4"">Created</th>
+          <th class="col-md-4">Name</th>
+          <th class="col-md-4">Provisioner</th>
+          <th class="col-md-3">Created</th>
           <th class="status_column">Status</th>
-          <th class="action_column">Actions</th>
+          <th class="action_column">Info</th>
         </thead>
         <tbody>
           {% for cluster in clusters %}
@@ -55,13 +57,15 @@
           {% endfor %}
         </tbody>
       </table>
-      <div class="bulk-action">
-        <div class="disabled-wrapper">
-          <a class="btn btn-default confirm-delete bulk-delete" title="Delete cluster">
-            <i class="mdi mdi-delete-forever"></i>Delete
-          </a>
+      {% if clusters %}
+        <div class="bulk-action">
+          <div class="disabled-wrapper">
+            <a class="btn btn-default confirm-delete bulk-delete" title="Delete cluster">
+              <i class="mdi mdi-delete-forever"></i>Delete
+            </a>
+          </div>
         </div>
-      </div>
+      {% endif %}
     </div>
   </div>
 
@@ -199,25 +203,22 @@ setInterval(function(){
 }, 15000);
 
 $(document).ready(function() {
-  $('tr.clickable').click(function(e) {
-    if (e.target.tagName === 'TD') {
-      var rowCheckbox = $($(e.target).parent().find('input[type="checkbox"].select-cluster')[0]);
-      rowCheckbox.prop('checked', !rowCheckbox.is(':checked')).trigger('change');
-    }
-  });
-
   // Bulk delete operation on clusters
   var selectAllCheckbox = $('input[type="checkbox"].select-all'),
-      selectRowCheckboxes = $('input[type="checkbox"].select-cluster'),
+      selectRowCheckboxes = $('input[type="checkbox"]:not(:disabled).select-cluster'),
       deleteButton = $('a.bulk-delete'),
       checkedRowsSelector = 'input[type="checkbox"].select-cluster:checked';
 
+  if (!$(selectRowCheckboxes).get().length) {
+    selectAllCheckbox.prop('disabled', true);
+    var label = $(selectAllCheckbox.next('label')[0]);
+    label.addClass('disabled-wrapper');
+    $(label.find('.checkbox-all')[0]).addClass('disabled');
+  }
+
   var setDeleteButtonState = (enable) => {
-    if (enable) {
-      deleteButton.removeClass('disabled');
-    } else {
-      deleteButton.addClass('disabled');
-    }
+    // "disabled" prop is not allowed for anchors, so we use classes instead
+    enable ? deleteButton.removeClass('disabled') : deleteButton.addClass('disabled');
   }
   var getSelectedClusterNames = () => $(checkedRowsSelector).map(function() {
     return this.value;
@@ -238,9 +239,11 @@ $(document).ready(function() {
   }
 
   setDeleteButtonState(selectRowCheckboxes.is(':checked'));
+  setButtonTarget();
+
   selectAllCheckbox.bind('change', function () {
     var allChecked = selectAllCheckbox.is(':checked');
-    $('input[type="checkbox"].select-cluster').prop('checked', allChecked);
+    selectRowCheckboxes.prop('checked', allChecked);
     setDeleteButtonState(allChecked);
     if (allChecked) {
       setButtonTarget();
@@ -249,6 +252,14 @@ $(document).ready(function() {
   selectRowCheckboxes.bind('change', function () {
     setDeleteButtonState(selectRowCheckboxes.is(':checked'));
     setButtonTarget();
+  });
+
+  // Handle table row click
+  $('tr.clickable').click(function(e) {
+    if (e.target.tagName === 'TD') {
+      var rowCheckbox = $($(e.target).parent().find(selectRowCheckboxes)[0]);
+      rowCheckbox.prop('checked', !rowCheckbox.is(':checked')).trigger('change');
+    }
   });
 });
 </script>

--- a/kqueen_ui/blueprints/ui/templates/ui/index.html
+++ b/kqueen_ui/blueprints/ui/templates/ui/index.html
@@ -244,20 +244,14 @@ setInterval(function(){
 }, 15000);
 
 $(document).ready(function() {
-  handleBulkDelete(
-    'input[type="checkbox"].select-all-clusters',
-    'input[type="checkbox"].select-cluster',
-    'a.bulk-delete-clusters',
-    (ids) => `/ui/clusters/${ids}/delete_bulk`,
-    'cluster'
-  );
-  handleBulkDelete(
-    'input[type="checkbox"].select-all-provisioners',
-    'input[type="checkbox"].select-provisioner',
-    'a.bulk-delete-provisioners',
-    (ids) => `/ui/provisioners/${ids}/delete_bulk`,
-    'provisioner'
-  );
+  var bulkTargets = ['cluster', 'provisioner'];
+  bulkTargets.forEach((target) => handleBulkDelete(
+    `input[type="checkbox"].select-all-${target}s`,
+    `input[type="checkbox"].select-${target}`,
+    `a.bulk-delete-${target}s`,
+    (ids) => `/ui/${target}s/${ids}/delete_bulk`,
+    target
+  ));
 });
 </script>
 {% endblock %}

--- a/kqueen_ui/blueprints/ui/templates/ui/index.html
+++ b/kqueen_ui/blueprints/ui/templates/ui/index.html
@@ -37,8 +37,9 @@
       </div>
       <table class="table table-hover">
         <thead>
-          <th class="col-md-1">
-            <input type="checkbox" class="select-all" />
+          <th class="col-md--1">
+            <input type="checkbox" class="select-all" id="select-all" />
+            <label for="select-all"><i class="mdi checkbox-all"></i></label>
           </th>
           <th class="col-md-3">Name</th>
           <th class="col-md-4"">Provisioner</th>
@@ -55,9 +56,11 @@
         </tbody>
       </table>
       <div class="bulk-action">
-        <a class="btn btn-default confirm-delete bulk-delete" title="Delete cluster">
-          <i class="mdi mdi-delete-forever"></i>Delete
-        </a>
+        <div class="disabled-wrapper">
+          <a class="btn btn-default confirm-delete bulk-delete" title="Delete cluster">
+            <i class="mdi mdi-delete-forever"></i>Delete
+          </a>
+        </div>
       </div>
     </div>
   </div>

--- a/kqueen_ui/blueprints/ui/templates/ui/index.html
+++ b/kqueen_ui/blueprints/ui/templates/ui/index.html
@@ -37,9 +37,12 @@
       </div>
       <table class="table table-hover">
         <thead>
-          <th class="col-md-4">Name</th>
-          <th class="col-md-4">Provisioner</th>
-          <th class="col-md-4">Created</th>
+          <th class="col-md-1">
+            <input type="checkbox" class="select-all" />
+          </th>
+          <th class="col-md-3">Name</th>
+          <th class="col-md-4"">Provisioner</th>
+          <th class="col-md-4"">Created</th>
           <th class="status_column">Status</th>
           <th class="action_column">Actions</th>
         </thead>
@@ -51,6 +54,11 @@
           {% endfor %}
         </tbody>
       </table>
+      <div class="bulk-action">
+        <a class="btn btn-default confirm-delete disabled bulk-delete" title="Delete cluster">
+          <i class="mdi mdi-delete-forever"></i>Delete
+        </a>
+      </div>
     </div>
   </div>
 
@@ -190,9 +198,53 @@ setInterval(function(){
 $(document).ready(function() {
   $('tr.clickable').click(function(e) {
     if (e.target.tagName === 'TD') {
-      var link = $(this).data('href');
-      if (link) window.location = link;
+      var rowCheckbox = $($(e.target).parent().find('input[type="checkbox"].select-cluster')[0]);
+      rowCheckbox.prop('checked', !rowCheckbox.is(':checked')).trigger('change');
     }
+  });
+
+  // Bulk delete operation on clusters
+  var selectAllCheckbox = $('input[type="checkbox"].select-all'),
+      selectRowCheckboxes = $('input[type="checkbox"].select-cluster'),
+      deleteButton = $('a.bulk-delete'),
+      checkedRowsSelector = 'input[type="checkbox"].select-cluster:checked';
+
+  var setDeleteButtonState = (enable) => {
+    if (enable) {
+      deleteButton.removeClass('disabled');
+    } else {
+      deleteButton.addClass('disabled');
+    }
+  }
+  var getSelectedClusterNames = () => $(checkedRowsSelector).map(function() {
+    return this.value;
+  }).get();
+  var getSelectedClusterIds = () => $(checkedRowsSelector).map(function() {
+    return this.name;
+  }).get();
+  var setButtonTarget = () => {
+    deleteButton.data('target', `/ui/clusters/${getSelectedClusterIds().join('+')}/delete_bulk`);
+    var text = '',
+        names = getSelectedClusterNames();
+    if (!$('input[type="checkbox"].select-cluster:not(:checked)').get().length) {
+      text = `ALL your clusters (${names.join(', ')})`;
+    } else {
+      text = `cluster${names.length === 1 ? '' : 's'} ${names.join(', ')}`;
+    }
+    deleteButton.data('name', text);
+  }
+
+  selectAllCheckbox.bind('change', function () {
+    var allChecked = selectAllCheckbox.is(':checked');
+    $('input[type="checkbox"].select-cluster').prop('checked', allChecked);
+    setDeleteButtonState(allChecked);
+    if (allChecked) {
+      setButtonTarget();
+    }
+  });
+  selectRowCheckboxes.bind('change', function () {
+    setDeleteButtonState(selectRowCheckboxes.is(':checked'));
+    setButtonTarget();
   });
 });
 </script>

--- a/kqueen_ui/blueprints/ui/templates/ui/index.html
+++ b/kqueen_ui/blueprints/ui/templates/ui/index.html
@@ -35,7 +35,7 @@
           </div>
         </div>
       </div>
-      <table class="table table-hover clusters-list">
+      <table class="table table-hover">
         <thead>
           <th class="col-md-1">
             {% if clusters %}
@@ -85,7 +85,7 @@
           </div>
         </div>
       </div>
-      <table class="table table-hover provisioners-list">
+      <table class="table table-hover">
         <thead>
           <th class="col-md-1">
             {% if provisioners %}
@@ -111,7 +111,7 @@
                 <input
                   type="checkbox"
                   id="select-provisioner-{{ provisioner.id }}"
-                  {% if cant_delete %} disabled{% endif %}
+                  {% if cant_delete %}disabled{% endif %}
                   class="select-provisioner"
                   name="{{ provisioner.id }}"
                   value="{{ provisioner.name }}"
@@ -244,14 +244,14 @@ setInterval(function(){
 }, 15000);
 
 $(document).ready(function() {
-  var bulkTargets = ['cluster', 'provisioner'];
-  bulkTargets.forEach((target) => handleBulkDelete(
-    `input[type="checkbox"].select-all-${target}s`,
-    `input[type="checkbox"].select-${target}`,
-    `a.bulk-delete-${target}s`,
-    (ids) => `/ui/${target}s/${ids}/delete_bulk`,
-    target
-  ));
+  var bulkDeleteTargets = ['cluster', 'provisioner'];
+  bulkDeleteTargets.forEach((target) => handleBulkDelete({
+    selectAllCheckboxSelector: `input[type="checkbox"].select-all-${target}s`,
+    rowCheckboxesSelector: `input[type="checkbox"].select-${target}`,
+    buttonSelector: `a.bulk-delete-${target}s`,
+    formTargetUrl: (ids) => `/ui/${target}s/${ids}/delete`,
+    targetName: target
+  }));
 });
 </script>
 {% endblock %}

--- a/kqueen_ui/blueprints/ui/templates/ui/partial/_cluster_row.html
+++ b/kqueen_ui/blueprints/ui/templates/ui/partial/_cluster_row.html
@@ -1,3 +1,5 @@
+{% from "ui/partial/tableaction.html" import render_cluster_row_actions with context %}
+
 {% macro render_cluster_row(cluster, index) %}
         {% set is_in_progress = cluster.state in config.CLUSTER_TRANSIENT_STATES %}
         {% set not_authorized = not is_authorized(session, 'cluster:delete', cluster) %}
@@ -8,7 +10,7 @@
           data-status="{{ cluster.state }}"
           data-href="{{ url_for('ui.cluster_detail', cluster_id=cluster.id) }}"
         >
-          <td class="col-md-1">
+          <td>
             <input
               type="checkbox"
               id="select-cluster-{{ cluster.id }}"
@@ -36,7 +38,7 @@
             {% endif %}
           </td>
           <td class="col-md-4">{{ cluster.provisioner.name }}</td>
-          <td class="col-md-3">{{ cluster.created_at }}</td>
+          <td class="col-md-4">{{ cluster.created_at }}</td>
           <td class="status_column">
             {{ cluster.state|cluster_status_icon|safe }}
           </td>
@@ -51,6 +53,7 @@
               <i class="mdi mdi-information-outline"></i>
             </a>
             {% endif %}
+            {{ render_cluster_row_actions(cluster) }}
           </td>
         </tr>
         {% if cluster.metadata %}

--- a/kqueen_ui/blueprints/ui/templates/ui/partial/_cluster_row.html
+++ b/kqueen_ui/blueprints/ui/templates/ui/partial/_cluster_row.html
@@ -11,10 +11,14 @@
           <td class="col-md-1">
             <input
               type="checkbox"
+              id="select-cluster-{{ cluster.id }}"
               class="select-cluster"
               name="{{ cluster.id }}"
               value="{{ cluster.name }}"
             />
+            <label for="select-cluster-{{ cluster.id }}">
+              <i class="mdi checkbox-cluster"></i>
+            </label>
           </td>
           <td class="col-md-3 clickable-cluster-name">
             {% if is_authorized(session, 'cluster:get', cluster) %}

--- a/kqueen_ui/blueprints/ui/templates/ui/partial/_cluster_row.html
+++ b/kqueen_ui/blueprints/ui/templates/ui/partial/_cluster_row.html
@@ -21,7 +21,7 @@
               for="select-cluster-{{ cluster.id }}"
               {% if cant_delete %}class="disabled-wrapper"{% endif %}
             >
-              <i class="mdi checkbox-cluster{% if cant_delete %} disabled{% endif %}"></i>
+              <i class="mdi checkbox-row{% if cant_delete %} disabled{% endif %}"></i>
             </label>
           </td>
           <td class="col-md-4 clickable-cluster-name">

--- a/kqueen_ui/blueprints/ui/templates/ui/partial/_cluster_row.html
+++ b/kqueen_ui/blueprints/ui/templates/ui/partial/_cluster_row.html
@@ -12,7 +12,7 @@
             <input
               type="checkbox"
               id="select-cluster-{{ cluster.id }}"
-              {% if cant_delete %} disabled{% endif %}
+              {% if cant_delete %}disabled{% endif %}
               class="select-cluster"
               name="{{ cluster.id }}"
               value="{{ cluster.name }}"

--- a/kqueen_ui/blueprints/ui/templates/ui/partial/_cluster_row.html
+++ b/kqueen_ui/blueprints/ui/templates/ui/partial/_cluster_row.html
@@ -16,7 +16,7 @@
               value="{{ cluster.name }}"
             />
           </td>
-          <td class="col-md-3">
+          <td class="col-md-3 clickable-cluster-name">
             {% if is_authorized(session, 'cluster:get', cluster) %}
             <div class="cluster-name">
               <a href="{{ url_for('ui.cluster_detail', cluster_id=cluster.id) }}">

--- a/kqueen_ui/blueprints/ui/templates/ui/partial/_cluster_row.html
+++ b/kqueen_ui/blueprints/ui/templates/ui/partial/_cluster_row.html
@@ -8,7 +8,15 @@
           data-status="{{ cluster.state }}"
           data-href="{{ url_for('ui.cluster_detail', cluster_id=cluster.id) }}"
         >
-          <td class="col-md-4">
+          <td class="col-md-1">
+            <input
+              type="checkbox"
+              class="select-cluster"
+              name="{{ cluster.id }}"
+              value="{{ cluster.name }}"
+            />
+          </td>
+          <td class="col-md-3">
             {% if is_authorized(session, 'cluster:get', cluster) %}
             <div class="cluster-name">
               <a href="{{ url_for('ui.cluster_detail', cluster_id=cluster.id) }}">

--- a/kqueen_ui/blueprints/ui/templates/ui/partial/_cluster_row.html
+++ b/kqueen_ui/blueprints/ui/templates/ui/partial/_cluster_row.html
@@ -1,7 +1,7 @@
-{% from "ui/partial/tableaction.html" import render_cluster_row_actions with context %}
-
 {% macro render_cluster_row(cluster, index) %}
         {% set is_in_progress = cluster.state in config.CLUSTER_TRANSIENT_STATES %}
+        {% set not_authorized = not is_authorized(session, 'cluster:delete', cluster) %}
+        {% set cant_delete = cluster.state == config.CLUSTER_PROVISIONING_STATE or not_authorized %}
         <tr
           class="clickable{% if is_in_progress %} in-transition{% endif %}"
           data-index="{{ index }}"
@@ -12,15 +12,19 @@
             <input
               type="checkbox"
               id="select-cluster-{{ cluster.id }}"
+              {% if cant_delete %} disabled{% endif %}
               class="select-cluster"
               name="{{ cluster.id }}"
               value="{{ cluster.name }}"
             />
-            <label for="select-cluster-{{ cluster.id }}">
-              <i class="mdi checkbox-cluster"></i>
+            <label
+              for="select-cluster-{{ cluster.id }}"
+              {% if cant_delete %}class="disabled-wrapper"{% endif %}
+            >
+              <i class="mdi checkbox-cluster{% if cant_delete %} disabled{% endif %}"></i>
             </label>
           </td>
-          <td class="col-md-3 clickable-cluster-name">
+          <td class="col-md-4 clickable-cluster-name">
             {% if is_authorized(session, 'cluster:get', cluster) %}
             <div class="cluster-name">
               <a href="{{ url_for('ui.cluster_detail', cluster_id=cluster.id) }}">
@@ -32,7 +36,7 @@
             {% endif %}
           </td>
           <td class="col-md-4">{{ cluster.provisioner.name }}</td>
-          <td class="col-md-4">{{ cluster.created_at }}</td>
+          <td class="col-md-3">{{ cluster.created_at }}</td>
           <td class="status_column">
             {{ cluster.state|cluster_status_icon|safe }}
           </td>
@@ -47,7 +51,6 @@
               <i class="mdi mdi-information-outline"></i>
             </a>
             {% endif %}
-            {{ render_cluster_row_actions(cluster) }}
           </td>
         </tr>
         {% if cluster.metadata %}

--- a/kqueen_ui/blueprints/ui/templates/ui/partial/tableaction.html
+++ b/kqueen_ui/blueprints/ui/templates/ui/partial/tableaction.html
@@ -20,19 +20,6 @@
   </a>
 {% endmacro %}
 
-{% macro render_provisioner_row_actions(provisioner) %}
-  {% set delete_url = url_for('ui.provisioner_delete', provisioner_id=provisioner.id) %}
-  {% set cant_delete = not is_authorized(session, 'provisioner:delete', provisioner) %}
-  <a
-    data-target="{{ delete_url }}"
-    data-name="provisioner {{ provisioner.name }}"
-    class="confirm-delete{% if cant_delete %} disabled{% endif %}"
-    title="Delete provisioner"
-  >
-    <i class="mdi mdi-delete-forever"></i>
-  </a>
-{% endmacro %}
-
 {% macro render_member_table_actions() %}
   {% set invite_url = url_for('ui.user_invite') %}
   {% set cant_create = not is_authorized(session, 'user:create') %}

--- a/kqueen_ui/blueprints/ui/templates/ui/partial/tableaction.html
+++ b/kqueen_ui/blueprints/ui/templates/ui/partial/tableaction.html
@@ -9,20 +9,6 @@
   </a>
 {% endmacro %}
 
-{% macro render_cluster_row_actions(cluster) %}
-  {% set cant_get = not is_authorized(session, 'cluster:get', cluster) %}
-  {% set delete_url = url_for('ui.cluster_delete', cluster_id=cluster.id) %}
-  {% set cant_delete = ( cluster.state == config.CLUSTER_PROVISIONING_STATE or not is_authorized(session, 'cluster:delete', cluster) ) %}
-  <a
-    data-target="{{ delete_url }}"
-    data-name="cluster {{ cluster.name }}"
-    class="confirm-delete{% if cant_delete %} disabled{% endif %}"
-    title="Delete cluster"
-  >
-    <i class="mdi mdi-delete-forever"></i>
-  </a>
-{% endmacro %}
-
 {% macro render_provisioner_table_actions() %}
   {% set create_url = url_for('ui.provisioner_create') %}
   {% set cant_create = not is_authorized(session, 'provisioner:create') %}

--- a/kqueen_ui/blueprints/ui/templates/ui/partial/tableaction.html
+++ b/kqueen_ui/blueprints/ui/templates/ui/partial/tableaction.html
@@ -9,6 +9,20 @@
   </a>
 {% endmacro %}
 
+{% macro render_cluster_row_actions(cluster) %}
+  {% set cant_get = not is_authorized(session, 'cluster:get', cluster) %}
+  {% set delete_url = url_for('ui.cluster_delete', cluster_ids=[cluster.id]) %}
+  {% set cant_delete = ( cluster.state == config.CLUSTER_PROVISIONING_STATE or not is_authorized(session, 'cluster:delete', cluster) ) %}
+  <a
+    data-target="{{ delete_url }}"
+    data-name="cluster {{ cluster.name }}"
+    class="confirm-delete{% if cant_delete %} disabled{% endif %}"
+    title="Delete cluster"
+  >
+    <i class="mdi mdi-delete-forever"></i>
+  </a>
+{% endmacro %}
+
 {% macro render_provisioner_table_actions() %}
   {% set create_url = url_for('ui.provisioner_create') %}
   {% set cant_create = not is_authorized(session, 'provisioner:create') %}
@@ -17,6 +31,19 @@
     class="btn btn-primary btn-sm{% if cant_create %} disabled{% endif %}"
   >
     Create provisioner
+  </a>
+{% endmacro %}
+
+{% macro render_provisioner_row_actions(provisioner) %}
+  {% set delete_url = url_for('ui.provisioner_delete', provisioner_ids=[provisioner.id]) %}
+  {% set cant_delete = not is_authorized(session, 'provisioner:delete', provisioner) %}
+  <a
+    data-target="{{ delete_url }}"
+    data-name="provisioner {{ provisioner.name }}"
+    class="confirm-delete{% if cant_delete %} disabled{% endif %}"
+    title="Delete provisioner"
+  >
+    <i class="mdi mdi-delete-forever"></i>
   </a>
 {% endmacro %}
 

--- a/kqueen_ui/blueprints/ui/test_views.py
+++ b/kqueen_ui/blueprints/ui/test_views.py
@@ -13,9 +13,9 @@ import pytest
     ('ui.user_change_password', {}),
     ('ui.user_profile', {}),
     ('ui.provisioner_create', {}),
-    ('ui.provisioner_delete', {'provisioner_id': 1}),
+    ('ui.provisioner_delete', {'provisioner_ids': [1]}),
     ('ui.cluster_create', {}),
-    ('ui.cluster_delete', {'cluster_id': 1}),
+    ('ui.cluster_delete', {'cluster_ids': [1]}),
     ('ui.cluster_deployment_status', {'cluster_id': 1}),
     ('ui.cluster_detail', {'cluster_id': 1}),
     ('ui.cluster_kubeconfig', {'cluster_id': 1}),
@@ -122,7 +122,8 @@ def test_provisioner_create(client_login):
 
 
 def test_provisioner_delete(client_login, provisioner):
-    response = client_login.get(url_for('ui.provisioner_delete', provisioner_id=provisioner['id']))
+    response = client_login.get(url_for('ui.provisioner_delete',
+                                        provisioner_ids=[provisioner['id']]))
     assert response.status_code == 302
     assert response.headers['Location'].endswith(url_for('ui.index', _anchor='provisionersTab'))
 
@@ -139,7 +140,7 @@ def test_cluster_create(client_login, provisioner):
 
 
 def test_cluster_delete(client_login, cluster):
-    response = client_login.get(url_for('ui.cluster_delete', cluster_id=cluster['id']))
+    response = client_login.get(url_for('ui.cluster_delete', cluster_ids=[cluster['id']]))
     assert response.status_code == 302
     assert response.headers['Location'].endswith(url_for('ui.index'))
 

--- a/kqueen_ui/blueprints/ui/views.py
+++ b/kqueen_ui/blueprints/ui/views.py
@@ -540,31 +540,6 @@ class ProvisionerCreate(KQueenView):
         return render_template('ui/provisioner_create.html', form=form)
 
 
-# TODO: remove this one?
-class ProvisionerDelete(KQueenView):
-    decorators = [login_required]
-    methods = ['GET']
-    validation_hint = 'uuid'
-
-    def handle(self, provisioner_id):
-        # TODO: block deletion of used provisioner on backend, not here
-        clusters = self.kqueen_request('cluster', 'list')
-        provisioner = self.kqueen_request('provisioner', 'get', fnargs=(provisioner_id,))
-        used_provisioners = [p['id'] for p in [c['provisioner'] for c in clusters]]
-
-        if provisioner_id not in used_provisioners:
-            self.kqueen_request('provisioner', 'delete', fnargs=(provisioner_id,))
-            msg = 'Provisioner {} deleted.'.format(provisioner['name'])
-            user_logger.debug('{}:{}'.format(user_prefix(session), msg))
-            flash(msg, 'success')
-        else:
-            msg = 'Provisioner {} is in use, cannot delete.'.format(provisioner['name'])
-            user_logger.debug('{}:{}'.format(user_prefix(session), msg))
-            flash(msg, 'warning')
-
-        return redirect(url_for('ui.index', _anchor='provisionersTab'))
-
-
 class ProvisionerDeleteBulk(KQueenView):
     decorators = [login_required]
     methods = ['GET']
@@ -589,12 +564,11 @@ class ProvisionerDeleteBulk(KQueenView):
 
 
 ui.add_url_rule('/provisioners/create', view_func=ProvisionerCreate.as_view('provisioner_create'))
-ui.add_url_rule('/provisioners/<provisioner_id>/delete', view_func=ProvisionerDelete.as_view('provisioner_delete'))
-ui.add_url_rule('/provisioners/<list:provisioner_ids>/delete_bulk',
-                view_func=ProvisionerDeleteBulk.as_view('provisioner_delete_bulk'))
+ui.add_url_rule('/provisioners/<list:provisioner_ids>/delete',
+                view_func=ProvisionerDeleteBulk.as_view('provisioner_delete'))
+
 
 # Cluster
-
 
 class ClusterCreate(KQueenView):
     decorators = [login_required]
@@ -668,30 +642,6 @@ class ClusterCreate(KQueenView):
             flash(msg, 'success')
             return redirect(url_for('ui.index'))
         return render_template('ui/cluster_create.html', form=form)
-
-
-# TODO: delete this one?
-class ClusterDelete(KQueenView):
-    decorators = [login_required]
-    methods = ['GET']
-    validation_hint = 'uuid'
-
-    def handle(self, cluster_id):
-        cluster = self.kqueen_request('cluster', 'get', fnargs=(cluster_id,))
-        msg = 'Cluster {} successfully deleted.'.format(cluster['name'])
-
-        if cluster['provisioner']['engine'] == 'kqueen.engines.ManualEngine':
-            flash('Manual Engine does not support cluster deleting, cluster will be detached.', 'warning')
-            msg = 'Cluster {} successfully detached.'.format(cluster['name'])
-
-        if cluster['state'] == app.config['CLUSTER_PROVISIONING_STATE']:
-            # TODO: handle state together with policies in helper for allowed table actions
-            flash('Cannot delete clusters during provisioning.', 'warning')
-            return redirect(request.environ.get('HTTP_REFERER', url_for('ui.index')))
-        self.kqueen_request('cluster', 'delete', fnargs=(cluster_id,))
-        user_logger.debug('{}:{}'.format(user_prefix(session), msg))
-        flash(msg, 'success')
-        return redirect(url_for('ui.index'))
 
 
 class ClusterDeleteBulk(KQueenView):
@@ -864,10 +814,8 @@ class ClusterRow(KQueenView):
 
 ui.add_url_rule('/clusters/create',
                 view_func=ClusterCreate.as_view('cluster_create'))
-ui.add_url_rule('/clusters/<list:cluster_ids>/delete_bulk',
-                view_func=ClusterDeleteBulk.as_view('cluster_delete_bulk'))
-ui.add_url_rule('/clusters/<cluster_id>/delete',
-                view_func=ClusterDelete.as_view('cluster_delete'))
+ui.add_url_rule('/clusters/<list:cluster_ids>/delete',
+                view_func=ClusterDeleteBulk.as_view('cluster_delete'))
 ui.add_url_rule('/clusters/<cluster_id>/deployment-status',
                 view_func=ClusterDeploymentStatus.as_view('cluster_deployment_status'))
 ui.add_url_rule('/clusters/<cluster_id>/detail',

--- a/kqueen_ui/converters.py
+++ b/kqueen_ui/converters.py
@@ -1,0 +1,9 @@
+from werkzeug.routing import BaseConverter
+
+
+class ListConverter(BaseConverter):
+    def to_python(self, value):
+        return value.split('+')
+
+    def to_url(self, values):
+        return '+'.join(BaseConverter.to_url(value) for value in values)

--- a/kqueen_ui/converters.py
+++ b/kqueen_ui/converters.py
@@ -6,4 +6,4 @@ class ListConverter(BaseConverter):
         return value.split('+')
 
     def to_url(self, values):
-        return '+'.join(BaseConverter.to_url(value) for value in values)
+        return '+'.join(super(ListConverter, self).to_url(value) for value in values)

--- a/kqueen_ui/generic_views.py
+++ b/kqueen_ui/generic_views.py
@@ -114,3 +114,7 @@ class KQueenView(View):
             if self.validation_hint == 'uuid':
                 for kwarg in kwargs.values():
                     self._validate_uuid(kwarg)
+            if self.validation_hint == 'uuid_list':
+                for kwarg in kwargs.values():
+                    for kw in kwarg:
+                        self._validate_uuid(kw)

--- a/kqueen_ui/server.py
+++ b/kqueen_ui/server.py
@@ -20,6 +20,9 @@ logger = logging.getLogger('kqueen_ui')
 def create_app(config_file=None):
     app = Flask(__name__, static_folder='./asset/static')
 
+    from .converters import ListConverter  # it's here to avoid circular imports
+    app.url_map.converters['list'] = ListConverter
+
     app.register_blueprint(manager, url_prefix='/manager')
     app.register_blueprint(registration, url_prefix='/registration')
     app.register_blueprint(ui, url_prefix='/ui')

--- a/kqueen_ui/server.py
+++ b/kqueen_ui/server.py
@@ -4,6 +4,7 @@ from flask import Flask, redirect, request, url_for
 from kqueen_ui.blueprints.manager.views import manager
 from kqueen_ui.blueprints.registration.views import registration
 from kqueen_ui.blueprints.ui.views import ui
+from kqueen_ui.converters import ListConverter
 from kqueen_ui.exceptions import KQueenAPIException
 from kqueen_ui.utils.filters import filters, context_processors
 from kqueen_ui.utils.loggers import setup_logging
@@ -20,7 +21,6 @@ logger = logging.getLogger('kqueen_ui')
 def create_app(config_file=None):
     app = Flask(__name__, static_folder='./asset/static')
 
-    from .converters import ListConverter  # it's here to avoid circular imports
     app.url_map.converters['list'] = ListConverter
 
     app.register_blueprint(manager, url_prefix='/manager')


### PR DESCRIPTION
- delete icons for each cluster and provisioner are deleted
- checkboxes for each row are added
- buttons to delete selected clusters and provisioners are added
- rows are clickable, on click checkbox is selected
- cluster name cells are clickable, on click cluster page is opened
- delete views now support bulk delete; syntax: `/ui/clusters/<cluster1_id>+<cluster2_id>/delete`