### PR TITLE
Fix parameter fields representation issues

### DIFF
--- a/kqueen_ui/asset/dynamic/scss/main.scss
+++ b/kqueen_ui/asset/dynamic/scss/main.scss
@@ -434,6 +434,10 @@ label.error {
   margin: 15px;
   td {
     padding: 0 20px 10px 0;
+    vertical-align: top;
+    button {
+      margin-top: 5px;
+    }
   }
   th {
     color: $gray;
@@ -441,8 +445,16 @@ label.error {
       font-weight: 500;
     }
   }
+  input[type="text"].form-control {
+    min-width: 230px;
+  }
   textarea.form-control {
     height: 38px;
+    min-width: 230px;
+    min-height: 38px;
+    max-width: 600px;
+    width: 100%;
+    margin-right: 0 !important;
   }
 }
 

--- a/kqueen_ui/asset/static/js/fieldlist.js
+++ b/kqueen_ui/asset/static/js/fieldlist.js
@@ -1,10 +1,10 @@
 function fieldList() {
   $('div[id$=fieldset]').each(function () {
     var $this = $(this);
-    //  Hide button that can remove last tr
-    $this.find('[data-toggle=fieldset-entry] td:last').hide();
+    // Hide the button that can remove last row
+    $this.find('[data-toggle=fieldset-entry]:first td:last').hide();
 
-    // Add new entry
+    // Add a new entry
     $this.find('button[id$=fieldset-add-row]').click(function () {
       var lastRow = $this.find('[data-toggle=fieldset-entry]:last');
       var newRow = lastRow.clone(true, true);
@@ -14,7 +14,6 @@ function fieldList() {
       var elemNum = parseInt(newElemID.replace(/.*-(\d{1,4})-.*/, '$1')) + 1;
       newRow.attr('data-id', elemNum);
       newRow.find(':input').each(function () {
-
         var id = $(this).attr('id').replace('-' + (elemNum - 1) + '-', '-' + (elemNum) + '-');
         $(this).attr('name', id).attr('id', id).val('');
       });
@@ -22,7 +21,7 @@ function fieldList() {
       lastRow.after(newRow);
     });
 
-    // Remove row
+    // Remove the row
     $this.find('button[id$=remove-row]').click(function () {
       if ($this.find('[data-toggle=fieldset-entry]').length > 1) {
         var row = $(this).closest('[data-toggle=fieldset-entry]');

--- a/kqueen_ui/blueprints/ui/templates/ui/partial/selectform.html
+++ b/kqueen_ui/blueprints/ui/templates/ui/partial/selectform.html
@@ -164,34 +164,34 @@ document.addEventListener("DOMContentLoaded", function() {
     >
       <i class="mdi mdi-plus"></i>
     </button>
-    <table class="fieldset-table">
-      {% for subform in field %}
+    {% if field %}
+      <table class="fieldset-table">
         <tr>
-          {% for subfield in subform %}
+          {% for subfield in field[0] %}
             <th>{{ subfield.label }}</th>
           {% endfor %}
           <th></th>
         </tr>
-      {% endfor %}
-      {% for subform in field %}
-        <tr data-toggle="fieldset-entry">
-          {% for subfield in subform %}
-            <td> {{ subfield(class="form-control")|safe }} </td>
-          {% endfor %}
-          <td>
-            <button
-              class="btn btn-xs btn-danger"
-              type="button"
-              data-toggle="tooltip"
-              title="Remove parameter"
-              id="{{ field.name }}-{{ loop.index0 }}-remove-row">
-              <i class="mdi mdi-minus"></i>
-            </button>
-          </td>
-        </tr>
-      {% endfor %}
-    </table>
-    {% if field.errors %}
+        {% for subform in field %}
+          <tr data-toggle="fieldset-entry">
+            {% for subfield in subform %}
+              <td>{{ subfield(class="form-control")|safe }}</td>
+            {% endfor %}
+            <td>
+              <button
+                class="btn btn-xs btn-danger"
+                type="button"
+                data-toggle="tooltip"
+                title="Remove parameter"
+                id="{{ field.name }}-{{ loop.index0 }}-remove-row"
+              >
+                <i class="mdi mdi-minus"></i>
+              </button>
+            </td>
+          </tr>
+        {% endfor %}
+      </table>
+    {% elif field.errors %}
       <span class="help-block">
         {% for error in field.errors %}
           {{ error }}


### PR DESCRIPTION
The following is fixed:
- textarea width and height could break layout;
- after submitting cluster creation with empty name, labels were
  duplicated for each new row; also remove button was displayed
  for the first row instead of the last one.