### PR TITLE
Remove namespace notation from the UI

### DIFF
--- a/kqueen_ui/asset/dynamic/scss/main.scss
+++ b/kqueen_ui/asset/dynamic/scss/main.scss
@@ -490,6 +490,10 @@ table {
 }
 
 .table-container {
+  h3 {
+    margin-top: 10px;
+    margin-bottom: 10px;
+  }
   .table-actions {
     padding-bottom: 24px;
     text-align: right;

--- a/kqueen_ui/blueprints/manager/templates/manager/organization_detail.html
+++ b/kqueen_ui/blueprints/manager/templates/manager/organization_detail.html
@@ -6,16 +6,22 @@
 {% block breadcrumb %}<li class="breadcrumb-item active">Manage Organization</li>{% endblock %}
 
 {% block content %}
-<h3>Members</h3>
 
 <div class="table-container">
-  <div class="table-actions">
-    <a
-      href="{{ url_for('manager.member_create', organization_id=organization.id) }}"
-      class="btn btn-primary btn-sm"
-    >
-      Add Member
-    </a>
+  <div class="row">
+    <div class="col-xs-8">
+      <h3>Members</h3>
+    </div>
+    <div class="col-xs-4">
+      <div class="table-actions">
+        <a
+          href="{{ url_for('manager.member_create', organization_id=organization.id) }}"
+          class="btn btn-primary btn-sm"
+        >
+          Add Member
+        </a>
+      </div>
+    </div>
   </div>
   <table class="table table-hover">
     <thead>

--- a/kqueen_ui/blueprints/manager/templates/manager/overview.html
+++ b/kqueen_ui/blueprints/manager/templates/manager/overview.html
@@ -3,17 +3,23 @@
 {% block page_header %}Overview{% endblock %}
 
 {% block content %}
-<h3>Organizations</h3>
 
 <div class="table-container">
-  <div class="table-actions">
-    <a
-      href="{{ url_for('manager.organization_create') }}"
-      role="button"
-      class="btn btn-primary btn-sm"
-    >
-      Create Organization
-    </a>
+  <div class="row">
+    <div class="col-xs-8">
+      <h3>Organizations</h3>
+    </div>
+    <div class="col-xs-4">
+      <div class="table-actions">
+        <a
+          href="{{ url_for('manager.organization_create') }}"
+          role="button"
+          class="btn btn-primary btn-sm"
+        >
+          Create Organization
+        </a>
+      </div>
+    </div>
   </div>
   <table class="table table-hover">
     <thead>

--- a/kqueen_ui/blueprints/manager/templates/manager/overview.html
+++ b/kqueen_ui/blueprints/manager/templates/manager/overview.html
@@ -17,21 +17,19 @@
   </div>
   <table class="table table-hover">
     <thead>
-      <th class="col-md-4">Namespace</th>
-      <th class="col-md-4">Name</th>
-      <th class="col-md-4">Created</th>
+      <th class="col-md">Name</th>
+      <th class="col-md">Created</th>
       <th class="action_column">Actions</th>
     </thead>
     <tbody>
       {% for organization in organizations %}
         <tr>
-          <td class="col-md-4">
-            <a href="{{ url_for('manager.organization_detail', organization_id=organization.id) }}">
-              {{ organization.namespace }}
-            </a>
+          <td class="col-md">
+             <a href="{{ url_for('manager.organization_detail', organization_id=organization.id) }}">
+               {{ organization.name }}
+             </a>
           </td>
-          <td class="col-md-4">{{ organization.name }}</td>
-          <td class="col-md-4">{{ organization.created_at }}</td>
+          <td class="col-md">{{ organization.created_at }}</td>
           <td class="action_column">
             {% set detail_url = url_for('manager.organization_detail', organization_id=organization.id) %}
             {% set delete_url = url_for('manager.organization_delete', organization_id=organization.id) %}
@@ -65,7 +63,7 @@
 <div class="table-container no-actions" id="tableClusters">
   <table class="table table-hover">
     <thead>
-      <th class="col-md-3">Namespace</th>
+      <th class="col-md-3">Organization</th>
       <th class="col-md-3">Name</th>
       <th class="col-md-2">Provisioner</th>
       <th class="col-md-4">Created</th>
@@ -94,7 +92,7 @@
 <div class="table-container no-actions" id="tableProvisioners">
   <table class="table table-hover">
     <thead>
-      <th class="col-md-3">Namespace</th>
+      <th class="col-md-3">Organization</th>
       <th class="col-md-3">Name</th>
       <th class="col-md-3">Engine</th>
       <th class="col-md-3">Created</th>

--- a/kqueen_ui/blueprints/manager/templates/manager/partial/cluster_table.html
+++ b/kqueen_ui/blueprints/manager/templates/manager/partial/cluster_table.html
@@ -1,7 +1,7 @@
 <div class="table-container no-actions" id="tableClusters">
   <table class="table table-hover">
     <thead>
-      <th class="col-md-3">Namespace</th>
+      <th class="col-md-3">Organization</th>
       <th class="col-md-3">Name</th>
       <th class="col-md-3">Provisioner</th>
       <th class="col-md-3">Created</th>
@@ -11,7 +11,7 @@
     <tbody>
       {% for cluster in clusters %}
         <tr {% if cluster.state in config.CLUSTER_TRANSIENT_STATES %} class="in-transition"{% endif %}>
-          <td class="col-md-3">{{ cluster._namespace }}</td>
+          <td class="col-md-3">{{ cluster.owner.organization.name }}</td>
           <td class="col-md-3">{{ cluster.name }}</td>
           <td class="col-md-3">{{ cluster.provisioner.name }}</td>
           <td class="col-md-3">{{ cluster.created_at }}</td>

--- a/kqueen_ui/blueprints/manager/templates/manager/partial/provisioner_table.html
+++ b/kqueen_ui/blueprints/manager/templates/manager/partial/provisioner_table.html
@@ -1,7 +1,7 @@
 <div class="table-container no-actions" id="tableProvisioners">
   <table class="table table-hover">
     <thead>
-      <th class="col-md-3">Namespace</th>
+      <th class="col-md-3">Organization</th>
       <th class="col-md-3">Name</th>
       <th class="col-md-3">Engine</th>
       <th class="col-md-3">Created</th>
@@ -11,7 +11,7 @@
     <tbody>
       {% for provisioner in provisioners %}
         <tr>
-          <td class="col-md-3">{{ provisioner._namespace }}</td>
+          <td class="col-md-3">{{ provisioner.owner.organization.name }}</td>
           <td class="col-md-3">{{ provisioner.name }}</td>
           <td class="col-md-3">{{ provisioner.verbose_name }}</td>
           <td class="col-md-3">{{ provisioner.created_at }}</td>


### PR DESCRIPTION
Use organization name instead, since from the UI side
we operates with organizations and etcd implementation
is not important and overloads interface.